### PR TITLE
Selecting sorted results from database - Xwind

### DIFF
--- a/src/services/probes/probes.service.js
+++ b/src/services/probes/probes.service.js
@@ -92,6 +92,8 @@ export default {
                 direction -= bearing
                 if (direction < 0) direction += 360
                 feature.properties[directionElement + 'BearingDirection'] = direction
+			        	feature.properties['customHeadWindSpeed'] = (_.toNumber(norm)/0.514) * Math.cos(_.toNumber(direction) * Math.PI / 180.0)
+                feature.properties['customCrossWindSpeed'] = (_.toNumber(norm)/0.514) * Math.sin(_.toNumber(direction) * Math.PI / 180.0)
               }
             }
           }

--- a/src/services/probes/probes.service.js
+++ b/src/services/probes/probes.service.js
@@ -92,8 +92,8 @@ export default {
                 direction -= bearing
                 if (direction < 0) direction += 360
                 feature.properties[directionElement + 'BearingDirection'] = direction
-			        	feature.properties['customHeadWindSpeed'] = (_.toNumber(norm)/0.514) * Math.cos(_.toNumber(direction) * Math.PI / 180.0)
-                feature.properties['customCrossWindSpeed'] = (_.toNumber(norm)/0.514) * Math.sin(_.toNumber(direction) * Math.PI / 180.0)
+			        	feature.properties['headWindSpeed'] = (_.toNumber(norm)/0.514) * Math.cos(_.toNumber(direction) * Math.PI / 180.0)
+                feature.properties['crossWindSpeed'] = (_.toNumber(norm)/0.514) * Math.sin(_.toNumber(direction) * Math.PI / 180.0)
               }
             }
           }


### PR DESCRIPTION
### Summary of functionality
- This functionality is for implementation of  a requirement specific to x-wind.
- The fields crosswindspeed and headwindspeed are added to database so that whenever a user wants to 
  fetch runway results, he can get the automatically sorted results based on database fields.
- The UI related to this has been implemented in runwayseeker.vue for xwind

